### PR TITLE
Fix format of date_code property example.

### DIFF
--- a/docs/guide/usage/mqtt_topics_and_message_structure.md
+++ b/docs/guide/usage/mqtt_topics_and_message_structure.md
@@ -109,7 +109,7 @@ Example payload:
             "description":"Mi power plug ZigBee"
         },
         "power_source":"Mains (single phase)",
-        "date_code":"02-28-2017",
+        "date_code":"20170228",
         "model_id":"lumi.plug",
         "interviewing":false,
         "interview_completed":true
@@ -154,7 +154,7 @@ Example payload:
         "friendly_name":"my_sensor",
         "definition":null,
         "power_source":"Battery",
-        "date_code":"04-28-2019",
+        "date_code":"20190428",
         "model_id":null,
         "interviewing":false,
         "interview_completed":true


### PR DESCRIPTION
In a real world example, I see the value `"date_code": "20180828"`. It seams that the documentation is out of date?